### PR TITLE
fix stmt regex and highlight , as an operator

### DIFF
--- a/syntax/hamlet.vim
+++ b/syntax/hamlet.vim
@@ -26,9 +26,9 @@ syn match hmHsOp contained /\(\$\|\.\)/
 syn match hmTmpl /\^{[^}]*}/ contains=hmString,hmHsOp
 syn match hmVar /\#{[^}]*}/ contains=hmString,hsHsOp
 syn match hmExp /@{[^}]*}/ contains=hmString,hmHsOp
-syn match hmStmt /\$[^\\n]*/ contains=hmFunc,hmBindOp
+syn match hmStmt /^\s*\$.\+$/ contains=hmFunc,hmStmtOps
 syn match hmFunc contained /\$\(maybe\|nothing\|forall\|if\|elseif\|else\|with\)/
-syn match hmBindOp contained "<-"
+syn match hmStmtOps contained /\(<-\|,\)/
 syn match hmTrail display excludenl /\s\+$/
 
 syn include @HTML syntax/html.vim
@@ -45,16 +45,16 @@ else
   command! -nargs=+ HiLink hi def link <args>
 endif
 
-HiLink hmString String
-HiLink hmKey    Identifier
-HiLink hmHsOp   Operator
-HiLink hmAttr   Operator
-HiLink hmBindOp Operator
-HiLink hmTmpl   Number
-HiLink hmVar    Structure
-HiLink hmExp    Type
-HiLink hmFunc   Function
-HiLink hmTrail  Error
+HiLink hmString  String
+HiLink hmKey     Identifier
+HiLink hmHsOp    Operator
+HiLink hmAttr    Operator
+HiLink hmStmtOps Operator
+HiLink hmTmpl    Number
+HiLink hmVar     Structure
+HiLink hmExp     Type
+HiLink hmFunc    Function
+HiLink hmTrail   Error
 
 delcommand HiLink
 


### PR DESCRIPTION
The previous pull request introduced a broken regex. This pull request fixes that and also highlights , as an operator for valid code such as

$with a <- foo, b <- bar
