### PR TITLE
Streamlining filetype detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,8 @@ Provided is each `syntax/$language.vim` file for external templates as
 well as an `after/syntax/haskell.vim` which will properly highlight 
 quasi-quoted blocks inside a haskell source file.
 
-To use, just copy (or link) the contents of `./syntax` and 
-`./after/syntax` into your `~/.vim/syntax` and `~/.vim/after/syntax` 
-directories.
-
-Be sure to set the filetypes by extension in your `~/.vimrc`:
-
-    au BufEnter *.hamlet  setlocal filetype=hamlet
-    au BufEnter *.cassius setlocal filetype=cassius
-    au BufEnter *.julius  setlocal filetype=julius
+To use, just copy (or link) the contents of `./syntax`, `./after/syntax`, and
+`./ftdetect` into the corresponding directories under `~/.vim`. 
 
 ### Todo
 

--- a/ftdetect/shakespearean-templates.vim
+++ b/ftdetect/shakespearean-templates.vim
@@ -1,0 +1,3 @@
+au BufRead,BufNewFile *.hamlet  setf hamlet
+au BufRead,BufNewFile *.cassius setf cassius
+au BufRead,BufNewFile *.julius  setf julius


### PR DESCRIPTION
Following option B. in ':help new-filetype', this straightens up the suggested
autocommands and put them in a file under ftdetect/. Modifies the README
accordingly.

I reeaally wanted to put a reference to vim-pathogen in the README, but I'll let you check it and make the decision yourself. :) Seriously, it's so nice to just 'git clone' projects like this one under ~/.vim/bundle and have it magically work!
