### PR TITLE
Fixed multiline comments and added support for nerdcommenter

### DIFF
--- a/ftplugin/hamlet.vim
+++ b/ftplugin/hamlet.vim
@@ -1,0 +1,6 @@
+if exists("b:did_ftplugin")
+	finish
+endif
+let b:did_ftplugin = 1
+
+setlocal commentstring=<!--\ %s\ -->

--- a/syntax/hamlet.vim
+++ b/syntax/hamlet.vim
@@ -17,7 +17,7 @@ syntax spell toplevel
 syn match hmString  contained /"[^"]*"/ contains=hmVar,hmRoute,hmLang
 syn match hmNum     contained /\<[0-9]\+\>/
 syn match hmTrail   display excludenl /\s\+$/
-syn match hmComment display /\(\$#.*$\|<!--.*-->\)/
+syn match hmComment display /\(\$#.*$\|<!--\_.\{-}-->\)/
 
 " We use the leading anchor (^) to prevent invalid nesting from
 " highlighting; however, this prevents oneliner QQs from working.


### PR DESCRIPTION
This extends the fix for #13 to comments, and adds the `commentstring` variable for [nerdcommenter](https://github.com/scrooloose/nerdcommenter) support.

Thanks
