### PR TITLE
Add lucius/cassius ftplugin for CSS omnicompletion support

### DIFF
--- a/ftplugin/cassius.vim
+++ b/ftplugin/cassius.vim
@@ -1,0 +1,21 @@
+" Vim filetype plugin file
+" Language:         Cassius
+" Maintainer:       Alexandr Kurilin <alex@kurilin.net>
+" Latest Revision:  2014-11-07
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let b:undo_ftplugin = "setl com< cms< inc< fo< ofu<"
+
+setlocal omnifunc=csscomplete#CompleteCSS
+
+let &l:include = '^\s*@import\s\+\%(url(\)\='
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/ftplugin/lucius.vim
+++ b/ftplugin/lucius.vim
@@ -1,0 +1,21 @@
+" Vim filetype plugin file
+" Language:         Lucius
+" Maintainer:       Alexandr Kurilin <alex@kurilin.net>
+" Latest Revision:  2014-11-07
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let b:undo_ftplugin = "setl com< cms< inc< fo< ofu<"
+
+setlocal omnifunc=csscomplete#CompleteCSS
+
+let &l:include = '^\s*@import\s\+\%(url(\)\='
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
Because vim believes that the lucius filetype is different from the CSS filetype, we need to tell vim to us CSS's default CompleteCSS function as its omnifunc.

Lucius doesn't seem introduce any new keywords to CSS, so we should be able to re-use the CSS omnicompletion straight out of the box.

Another implementation option would be to declare that .lucius is actually CSS with setf css and then try to override the CSS defaults, although I'm not 100% sure how I'd accomplish that just yet.

Optionally I can add the same for .cassius. I don't use cassius myself, but we might as well add this feature to both, no?
