### PR TITLE
introduce flag to allow "invalid nesting"

### DIFF
--- a/syntax/hamlet.vim
+++ b/syntax/hamlet.vim
@@ -12,6 +12,10 @@ if !exists("main_syntax")
   let main_syntax = 'hamlet'
 endif
 
+if !exists("g:hamlet_prevent_invalid_nesting")
+  let g:hamlet_prevent_invalid_nesting = 1
+endif
+
 syntax spell toplevel
 
 syn match hmString  contained /"[^"]*"/ contains=hmVar,hmRoute,hmLang
@@ -21,7 +25,11 @@ syn match hmComment display /\(\$#.*$\|<!--\_.\{-}-->\)/
 
 " We use the leading anchor (^) to prevent invalid nesting from
 " highlighting; however, this prevents oneliner QQs from working.
-syn match hmKey /^\s*\\\?\s*<[^!]\_.\{-}>/ contains=hmVar,hmRoute,hmAttr,hmString,hmCond,hmAttrs
+if g:hamlet_prevent_invalid_nesting == 1
+  syn match hmKey /^\s*\\\?\s*<[^!]\_.\{-}>/ contains=hmVar,hmRoute,hmAttr,hmString,hmCond,hmAttrs
+else
+  syn match hmKey /\s*\\\?\s*<[^!]\_.\{-}>/ contains=hmVar,hmRoute,hmAttr,hmString,hmCond,hmAttrs
+endif
 syn match hmAttr contained /\(\.\|#\)[^ >]*/ contains=hmString,hmVar,hmRoute,hmLang
 syn match hmCond contained /:[^:]\+:\([^ ]*"[^"]*"\|[^ >]*\)/ contains=hmString,hmNumber,hmCondOp,hmHsOp
 


### PR DESCRIPTION
This might be a little controversial, therefore I made this a flag. The highlighting just looks very weird with one line hamlet snippets like "this <strong>is</strong> a test" not working.
