### PR TITLE
Add option to not highlight trailing spaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ The following options can be added to your `~/.vimrc` in order to
 to change the behaviour of this plugin.
 
 Allow one-liner QQs even if they have invalid nesting:
-```
+
+```vim
 let g:hamlet_prevent_invalid_nesting = 0
 ```
 
 Don't highlight empty space at the end of lines:
-```
+
+```vim
 let g:hamlet_highlight_trailing_space = 0
 ```
 

--- a/syntax/hamlet.vim
+++ b/syntax/hamlet.vim
@@ -26,9 +26,8 @@ syn match hmString  contained /"[^"]*"/ contains=hmVar,hmRoute,hmLang
 syn match hmNum     contained /\<[0-9]\+\>/
 syn match hmComment display /\(\$#.*$\|<!--\_.\{-}-->\)/
 
-" The user should be able to turn off trailing space highligting.
 if g:hamlet_highlight_trailing_space == 1
-  syn match hmTrail   display excludenl /\s\+$/
+  syn match hmTrail display excludenl /\s\+$/
 endif
 
 " We use the leading anchor (^) to prevent invalid nesting from


### PR DESCRIPTION
Add an option not to highlight trailing spaces as errors for hamlet
files.

Also add documentation to the README about the two possible options that
the user can set.
